### PR TITLE
投稿リストを種類別に調整できる指定方法に変更します。

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,50 +32,50 @@
         </div>
     </header>
     <article class="u-mt-M">
-        <ul class="p-postList">
-            <li class="p-postCard">
+        <ul class="p-postList p-postList--slider">
+            <li class="p-postCard p-postCard--slider">
                 <article>
-                    <a href="./post-card/post1.html" class="p-postCard__contents p-postCard__contents--gap-M">
-                        <figure class="p-postCard__thumb">
+                    <a href="./post-card/post1.html" class="p-postCard__contents p-postCard__contents--slider">
+                        <figure class="p-postCard__thumb p-postCard__thumb--slider">
                             <img src="./img/post-card-slider/post1.png" alt="投稿１" class="c-postImg">
                         </figure>
-                        <div class="p-postCard__desc p-postCard__desc--px-S c-postDesc">
+                        <div class="p-postCard__desc p-postCard__desc--slider c-postDesc">
                             <h2 class="c-postDesc__ttl c-postDesc__ttl--font-M">首里城の近くの一風変わった派手派手パーラーに行ってみた！！【ストリートパーラー SHURI】</h2>
                         </div>
                     </a>
                 </article>
             </li>
-            <li class="p-postCard">
+            <li class="p-postCard p-postCard--slider">
                 <article>
-                    <a href="./post-card/post1.html" class="p-postCard__contents p-postCard__contents--gap-M">
-                        <figure class="p-postCard__thumb">
+                    <a href="./post-card/post1.html" class="p-postCard__contents p-postCard__contents--slider">
+                        <figure class="p-postCard__thumb p-postCard__thumb--slider">
                             <img src="./img/post-card-slider/post2.png" alt="投稿１" class="c-postImg">
                         </figure>
-                        <div class="p-postCard__desc p-postCard__desc--px-S c-postDesc">
+                        <div class="p-postCard__desc p-postCard__desc--slider c-postDesc">
                             <h2 class="c-postDesc__ttl c-postDesc__ttl--font-M">こんなところに映えパーラー！？観光客も訪れる人気パーラーに行ってみた！！【パーラー みなと】</h2>
                         </div>
                     </a>
                 </article>
             </li>
-            <li class="p-postCard">
+            <li class="p-postCard p-postCard--slider">
                 <article>
-                    <a href="./post-card/post1.html" class="p-postCard__contents p-postCard__contents--gap-M">
-                        <figure class="p-postCard__thumb">
+                    <a href="./post-card/post1.html" class="p-postCard__contents p-postCard__contents--slider">
+                        <figure class="p-postCard__thumb p-postCard__thumb--slider">
                             <img src="./img/post-card-slider/post3.png" alt="投稿１" class="c-postImg">
                         </figure>
-                        <div class="p-postCard__desc p-postCard__desc--px-S c-postDesc">
+                        <div class="p-postCard__desc p-postCard__desc--slider c-postDesc">
                             <h2 class="c-postDesc__ttl c-postDesc__ttl--font-M">筆者がマジでおすすめするパーラー5選【沖縄パーラーシリーズ】</h2>
                         </div>
                     </a>
                 </article>
             </li>
-            <li class="p-postCard">
+            <li class="p-postCard p-postCard--slider">
                 <article>
-                    <a href="./post-card/post1.html" class="p-postCard__contents p-postCard__contents--gap-M">
-                        <figure class="p-postCard__thumb">
+                    <a href="./post-card/post1.html" class="p-postCard__contents p-postCard__contents--slider">
+                        <figure class="p-postCard__thumb p-postCard__thumb--slider">
                             <img src="./img/post-card-slider/post4.png" alt="投稿１" class="c-postImg">
                         </figure>
-                        <div class="p-postCard__desc p-postCard__desc--px-S c-postDesc">
+                        <div class="p-postCard__desc p-postCard__desc--slider c-postDesc">
                             <h2 class="c-postDesc__ttl c-postDesc__ttl--font-M">沖縄の人気パーラーランキングTOP10</h2>
                         </div>
                     </a>

--- a/scss/project/_p-postCard.scss
+++ b/scss/project/_p-postCard.scss
@@ -1,34 +1,34 @@
 @use "../foundation/mixin" as *;
 
 .p-postCard {
-    width: min(288px, 23vw);
-    @include max(tb) {
-        width: min(300px, 30.75vw);
-    }
     &:hover {
         @include hoverAction();
     }
+    &--slider {
+        width: min(288px, 23vw);
+        @include max(tb) {
+            width: min(300px, 30.75vw);
+        }
+    }
     &__contents {
         display: flex;
-        flex-direction: column;
-        &--gap {
-            &-M {
-                gap: clamp(0.6rem, 0.426rem + 0.63vw, 0.9rem);
-            }
+        &--slider {
+            flex-direction: column;
+            gap: clamp(0.6rem, 0.426rem + 0.63vw, 0.9rem);
         }
     }
     &__thumb {
-        width: 100%;
-        aspect-ratio: 1 / 0.625;
         box-shadow: 0px 2px 3px rgba(0, 0, 0, 0.18);
         border-radius: 2%;
         overflow: hidden;
+        &--slider {
+            width: 100%;
+            aspect-ratio: 1 / 0.625;
+        }
     }
     &__desc {
-        &--px {
-            &-S {
-                padding: 0 2px;
-            }
+        &--slider {
+            padding: 0 2px;
         }
     }
 }

--- a/scss/project/_p-postList.scss
+++ b/scss/project/_p-postList.scss
@@ -1,13 +1,14 @@
 @use "../foundation/mixin" as *;
 
 .p-postList {
-    @include wrapper();
     display: flex;
-    justify-content: space-between;
-    margin: 0 auto;
-    @include max(tb) {
-        & .p-postCard:last-child {
-            display: none;
+    &--slider {
+        justify-content: space-between;
+        @include wrapper();
+        @include max(tb) {
+            & .p-postCard:last-child {
+                display: none;
+            }
         }
     }
 }


### PR DESCRIPTION
# 概要
投稿リストと投稿カードのcss指定がスライダーのみに適用した指定方法になっていたため、種類別でも指定しやすい形に変更しました。