### PR TITLE
wordpressローカル環境用のdocker-compose.ymlを追加します。

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,27 @@
+version: "3.6"
+
+services:
+  wp:
+    image: wordpress:latest
+    environment:
+      - WORDPRESS_DB_NAME=wp-db
+      - WORDPRESS_DB_HOST=db
+      - WORDPRESS_DB_USER=user
+      - WORDPRESS_DB_PASSWORD=pass
+    depends_on:
+      - db
+    restart: always
+    ports:
+      - 8080:80
+
+  db:
+    image: mysql:latest
+    environment:
+      - MYSQL_ROOT_PASSWORD=password
+      - MYSQL_USER=user
+      - MYSQL_PASSWORD=pass
+      - MYSQL_DATABASE=wp-db
+    restart: always
+
+volumes:
+  db:


### PR DESCRIPTION
# 概要

wordpressのローカル環境を構築する用のdocker-composeファイルを追加したPRです。
DBデータやテーマフォルダのマウントは用意できしだい追記します。