### PR TITLE
トップカテゴリー取得処理を共通化します。

### DIFF
--- a/waraba-net-theme/front-page.php
+++ b/waraba-net-theme/front-page.php
@@ -46,16 +46,7 @@
                 <ul class="p-menuList p-menuList--post swiper-wrapper">
                     <li class="p-menuList__item c-postMenu swiper-slide">最新投稿</li>
                     <!-- トップカテゴリーを取得 -->
-                    <?php
-                        $top_categories = get_categories(
-                            array(
-                                'parent' => 0,
-                                'exclude' => 1,
-                                'hide_empty' => false,
-                                'orderby' => 'id'
-                            )
-                        );
-                    ?>
+                    <?php $top_categories = get_top_categories_info(); ?>
                     <?php foreach ( $top_categories as $top_category ) : ?>
                         <li class="p-menuList__item c-postMenu swiper-slide"><?= $top_category->name; ?></li>
                     <?php endforeach; ?>

--- a/waraba-net-theme/functions.php
+++ b/waraba-net-theme/functions.php
@@ -21,6 +21,19 @@ function get_post_child_category_name( $top_categories, $post_categories )
     return 'none';
 }
 
+// トップカテゴリー情報を取得
+function get_top_categories_info()
+{
+    return get_categories(
+        array(
+            'parent' => 0,
+            'exclude' => 1,
+            'hide_empty' => false,
+            'orderby' => 'id'
+        )
+    );
+}
+
 
 /* フック関数 */
 

--- a/waraba-net-theme/header.php
+++ b/waraba-net-theme/header.php
@@ -23,141 +23,72 @@
             </a>
             <nav class="p-header__menu">
                 <ul class="p-menuList p-menuList--header">
-                    <li class="p-menuList__item p-menuList__item--withSubMenu c-siteMenu">
-                        <span class="c-siteMenu__contents c-siteMenu__contents--withImg">
-                            <span class="c-siteMenu__img">
-                                <img src="<?= get_template_directory_uri(); ?>/img/header-menu-img/outing.png" alt="おでかけイメージ画像" class="c-img">
-                            </span>
-                            おでかけ
-                        </span>
-                        <ul class="p-menuList p-menuList--subMenu">
-                            <?php
-                                $top_category_id = get_categories( array( 'search' => 'outing' ) )[0]->term_id;
-                                $parent_categories = get_categories(
-                                    array(
-                                        'hide_empty' => '0',
-                                        'parent' => $top_category_id,
-                                        'orderby' => 'id'
-                                    )
-                                );
-                            ?>
-                            <?php foreach ( $parent_categories as $parent_category ) : ?>
-                                <li class="p-menuList__item c-siteMenu">
-                                    <span class="c-siteMenu__contents">
-                                        <a href="<?= get_category_link( $parent_category->term_id ); ?>"><?= $parent_category->name; ?></a>
-                                    </span>
-                                    <ul class="p-menuList p-menuList--subMenu">
-                                        <?php
-                                            $child_categories = get_categories(
-                                                array(
-                                                    'hide_empty' => '0',
-                                                    'parent' => $parent_category->term_id,
-                                                    'orderby' => 'id'
-                                                )
-                                            );
-                                        ?>
-                                        <?php foreach ( $child_categories as $child_category ) : ?>
-                                            <li class="p-menuList__item c-siteMenu">
-                                                <span class="c-siteMenu__contents">
-                                                    <a href="<?= get_category_link( $child_category->term_id ); ?>"><?= $child_category->name; ?></a>
-                                                </span>
-                                            </li>
-                                        <?php endforeach; ?>
-                                    </ul>
-                                </li>
-                            <?php endforeach; ?>
-                        </ul>
-                    </li>
-                    <li class="p-menuList__item p-menuList__item--withSubMenu c-siteMenu">
-                        <span class="c-siteMenu__contents c-siteMenu__contents--withImg">
-                            <span class="c-siteMenu__img">
-                                <img src="<?= get_template_directory_uri(); ?>/img/header-menu-img/meal.png" alt="食事イメージ画像" class="c-img">
-                            </span>
-                            食事
-                        </span>
-                        <ul class="p-menuList p-menuList--subMenu">
-                            <?php
-                                $top_category_id = get_categories( array( 'search' => 'meal' ) )[0]->term_id;
-                                $parent_categories = get_categories(
-                                    array(
-                                        'hide_empty' => '0',
-                                        'parent' => $top_category_id,
-                                        'orderby' => 'id'
-                                    )
-                                );
-                            ?>
-                            <?php foreach ( $parent_categories as $parent_category ) : ?>
-                                <li class="p-menuList__item c-siteMenu">
-                                    <span class="c-siteMenu__contents">
-                                        <a href="<?= get_category_link( $parent_category->term_id ); ?>"><?= $parent_category->name; ?></a>
-                                    </span>
-                                    <ul class="p-menuList p-menuList--subMenu">
-                                        <?php
-                                            $child_categories = get_categories(
-                                                array(
-                                                    'hide_empty' => '0',
-                                                    'parent' => $parent_category->term_id,
-                                                    'orderby' => 'id'
-                                                )
-                                            );
-                                        ?>
-                                        <?php foreach ( $child_categories as $child_category ) : ?>
-                                            <li class="p-menuList__item c-siteMenu">
-                                                <span class="c-siteMenu__contents">
-                                                    <a href="<?= get_category_link( $child_category->term_id ); ?>"><?= $child_category->name; ?></a>
-                                                </span>
-                                            </li>
-                                        <?php endforeach; ?>
-                                    </ul>
-                                </li>
-                            <?php endforeach; ?>
-                        </ul>
-                    </li>
-                    <li class="p-menuList__item p-menuList__item--withSubMenu c-siteMenu">
-                        <span class="c-siteMenu__contents c-siteMenu__contents--withImg">
-                            <span class="c-siteMenu__img">
-                                <img src="<?= get_template_directory_uri(); ?>/img/header-menu-img/life.png" alt="生活イメージ画像" class="c-img">
-                            </span>
-                            生活
-                        </span>
-                        <ul class="p-menuList p-menuList--subMenu">
-                            <?php
-                                $top_category_id = get_categories( array( 'search' => 'life' ) )[0]->term_id;
-                                $parent_categories = get_categories(
-                                    array(
-                                        'hide_empty' => '0',
-                                        'parent' => $top_category_id,
-                                        'orderby' => 'id'
-                                    )
-                                );
-                            ?>
-                            <?php foreach ( $parent_categories as $parent_category ) : ?>
-                                <li class="p-menuList__item c-siteMenu">
-                                    <span class="c-siteMenu__contents">
-                                        <a href="<?= get_category_link( $parent_category->term_id ); ?>"><?= $parent_category->name; ?></a>
-                                    </span>
-                                    <ul class="p-menuList p-menuList--subMenu">
-                                        <?php
-                                            $child_categories = get_categories(
-                                                array(
-                                                    'hide_empty' => '0',
-                                                    'parent' => $parent_category->term_id,
-                                                    'orderby' => 'id'
-                                                )
-                                            );
-                                        ?>
-                                        <?php foreach ( $child_categories as $child_category ) : ?>
-                                            <li class="p-menuList__item c-siteMenu">
-                                                <span class="c-siteMenu__contents">
-                                                    <a href="<?= get_category_link( $child_category->term_id ); ?>"><?= $child_category->name; ?></a>
-                                                </span>
-                                            </li>
-                                        <?php endforeach; ?>
-                                    </ul>
-                                </li>
-                            <?php endforeach; ?>
-                        </ul>
-                    </li>
+                    <?php $top_categories = get_top_categories_info(); ?>
+                    <?php foreach ( $top_categories as $top_category ) : ?>
+                        <?php
+                            switch ( $top_category->name ) {
+                                case 'おでかけ':
+                                    $img_file_name = 'outing.png';
+                                    $img_alt = 'おでかけイメージ画像';
+                                    $menu_text = 'おでかけ';
+                                    break;
+                                case '食事':
+                                    $img_file_name = 'meal.png';
+                                    $img_alt = '食事イメージ画像';
+                                    $menu_text = '食事';
+                                    break;
+                                case '生活':
+                                    $img_file_name = 'life.png';
+                                    $img_alt = '生活イメージ画像';
+                                    $menu_text = '生活';
+                                    break;
+                            }
+                        ?>
+                        <li class="p-menuList__item p-menuList__item--withSubMenu c-siteMenu">
+                            <a href="<?= get_category_link( $top_category->term_id ); ?>" class="c-siteMenu__contents c-siteMenu__contents--withImg">
+                                <span class="c-siteMenu__img">
+                                    <img src="<?= get_template_directory_uri(); ?>/img/header-menu-img/<?= $img_file_name; ?>" alt="<?= $img_alt; ?>" class="c-img">
+                                </span>
+                                <?= $menu_text; ?>
+                            </a>
+                            <ul class="p-menuList p-menuList--headerSub">
+                                <?php
+                                    $parent_categories = get_categories(
+                                        array(
+                                            'hide_empty' => '0',
+                                            'parent' => $top_category->term_id,
+                                            'orderby' => 'id'
+                                        )
+                                    );
+                                ?>
+                                <?php foreach ( $parent_categories as $parent_category ) : ?>
+                                    <li class="p-menuList__item c-siteMenu">
+                                        <span class="c-siteMenu__contents">
+                                            <a href="<?= get_category_link( $parent_category->term_id ); ?>"><?= $parent_category->name; ?></a>
+                                        </span>
+                                        <ul class="p-menuList p-menuList--headerSub">
+                                            <?php
+                                                $child_categories = get_categories(
+                                                    array(
+                                                        'hide_empty' => '0',
+                                                        'parent' => $parent_category->term_id,
+                                                        'orderby' => 'id'
+                                                    )
+                                                );
+                                            ?>
+                                            <?php foreach ( $child_categories as $child_category ) : ?>
+                                                <li class="p-menuList__item c-siteMenu">
+                                                    <span class="c-siteMenu__contents">
+                                                        <a href="<?= get_category_link( $child_category->term_id ); ?>"><?= $child_category->name; ?></a>
+                                                    </span>
+                                                </li>
+                                            <?php endforeach; ?>
+                                        </ul>
+                                    </li>
+                                <?php endforeach; ?>
+                            </ul>
+                        </li>
+                    <? endforeach; ?>
                     <li class="p-menuList__item c-siteMenu">
                         <a href="#" class="c-siteMenu__contents c-siteMenu__contents--withImg">
                             <span class="c-siteMenu__img">


### PR DESCRIPTION
# 概要
トップカテゴリー(おでかけ、食事、生活)の情報を取得する処理を関数かし、ヘッダーと記事一覧メニューで共通化したPRです。
カテゴリー情報の共通に伴って、ヘッダーメニューのHTML要素の共通化も一緒に行ってます。